### PR TITLE
Mattermost template: Ability to define docker image version

### DIFF
--- a/templates/baserow/meta.ts
+++ b/templates/baserow/meta.ts
@@ -4,7 +4,7 @@ export const meta = {
   name: "Baserow",
   description:
     "Open source no-code database and Airtable alternative. Create your own online database without technical experience. Our user friendly no-code tool gives you the powers of a developer without leaving your browser.",
-  instructions: "It may take several minutes to Baserow to boot up.",
+  instructions: "It may take several minutes for Baserow to boot up.",
   changeLog: [{ date: "2022-10-05", description: "first release" }],
   links: [
     { label: "Website", url: "https://baserow.io/" },

--- a/templates/mattermost/index.ts
+++ b/templates/mattermost/index.ts
@@ -21,7 +21,7 @@ export function generate(input: Input): Output {
       serviceName: input.appServiceName,
       source: {
         type: "image",
-        image: "mattermost/mattermost-team-edition:7.1",
+        image: input.dockerImageName,
       },
       mounts: [
         { type: "volume", name: "mattermost", mountPath: "/mattermost" },

--- a/templates/mattermost/meta.ts
+++ b/templates/mattermost/meta.ts
@@ -5,7 +5,13 @@ export const meta = {
   description:
     "Open source platform for developer collaboration. Secure, flexible, and integrated with the tools you love.",
   instructions: null,
-  changeLog: [{ date: "2022-07-12", description: "first release" }],
+  changeLog: [
+    { date: "2022-07-12", description: "first release" },
+    {
+      date: "2022-10-12",
+      description: "ablity to define custom docker image version",
+    },
+  ],
   links: [
     { label: "Website", url: "https://mattermost.com/" },
     { label: "Github", url: "https://github.com/mattermost/" },
@@ -13,6 +19,7 @@ export const meta = {
   contributors: [
     { name: "Bedeoan Raul", url: "https://github.com/bedeoan" },
     { name: "Andrei Canta", url: "https://github.com/deiucanta" },
+    { name: "Peter Fodor", url: "https://github.com/fodurrr" },
   ],
   schema: {
     type: "object",
@@ -20,6 +27,7 @@ export const meta = {
       "projectName",
       "domain",
       "appServiceName",
+      "dockerImageName",
       "databaseServiceName",
     ],
     properties: {
@@ -29,6 +37,11 @@ export const meta = {
         type: "string",
         title: "App Service Name",
         default: "mattermost",
+      },
+      dockerImageName: {
+        type: "string",
+        title: "Docker Image Name",
+        default: "mattermost/mattermost-team-edition:release-7.4",
       },
       databaseServiceName: {
         type: "string",
@@ -44,11 +57,13 @@ export const meta = {
 export type ProjectName = string;
 export type Domain = string;
 export type AppServiceName = string;
+export type DockerImageName = string;
 export type DatabaseServiceName = string;
 
 export interface Input {
   projectName: ProjectName;
   domain: Domain;
   appServiceName: AppServiceName;
+  dockerImageName: DockerImageName;
   databaseServiceName: DatabaseServiceName;
 }

--- a/templates/mattermost/meta.yaml
+++ b/templates/mattermost/meta.yaml
@@ -5,6 +5,8 @@ instructions: null
 changeLog:
   - date: 2022-07-12
     description: first release
+  - date: 2022-10-12
+    description: ablity to define custom docker image version
 links:
   - label: Website
     url: https://mattermost.com/
@@ -15,12 +17,15 @@ contributors:
     url: https://github.com/bedeoan
   - name: Andrei Canta
     url: https://github.com/deiucanta
+  - name: Peter Fodor
+    url: https://github.com/fodurrr
 schema:
   type: object
   required:
     - projectName
     - domain
     - appServiceName
+    - dockerImageName
     - databaseServiceName
   properties:
     projectName:
@@ -33,6 +38,10 @@ schema:
       type: string
       title: App Service Name
       default: mattermost
+    dockerImageName:
+      type: string
+      title: Docker Image Name
+      default: mattermost/mattermost-team-edition:release-7.4
     databaseServiceName:
       type: string
       title: Database Service Name


### PR DESCRIPTION
Hi,

I just modified the Mattermost template to be able to define the docker image before first pull.

I tried with json schema and it works fine.

