### PR TITLE
Update Hedgedoc to 1.9.6

### DIFF
--- a/templates/hedgedoc/meta.ts
+++ b/templates/hedgedoc/meta.ts
@@ -28,7 +28,7 @@ export const meta = {
       appServiceImage: {
         type: "string",
         title: "App Service Image",
-        default: "linuxserver/hedgedoc:1.9.4",
+        default: "linuxserver/hedgedoc:1.9.6",
       },
     },
   },

--- a/templates/hedgedoc/meta.yaml
+++ b/templates/hedgedoc/meta.yaml
@@ -35,4 +35,4 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: linuxserver/hedgedoc:1.9.4
+      default: linuxserver/hedgedoc:1.9.6


### PR DESCRIPTION
https://github.com/linuxserver/docker-hedgedoc/releases/tag/1.9.6-ls77