### PR TITLE
Updates: 2023-01-23

### DIFF
--- a/templates/jellyseerr/meta.ts
+++ b/templates/jellyseerr/meta.ts
@@ -29,7 +29,7 @@ export const meta = {
       appServiceImage: {
         type: "string",
         title: "App Service Image",
-        default: "fallenbagel/jellyseerr:1.2.1",
+        default: "fallenbagel/jellyseerr:1.3.0",
       },
     },
   },

--- a/templates/jellyseerr/meta.yaml
+++ b/templates/jellyseerr/meta.yaml
@@ -29,4 +29,4 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: fallenbagel/jellyseerr:1.2.1
+      default: fallenbagel/jellyseerr:1.3.0

--- a/templates/kanboard/meta.ts
+++ b/templates/kanboard/meta.ts
@@ -28,7 +28,7 @@ export const meta = {
       appServiceImage: {
         type: "string",
         title: "App Service Image",
-        default: "kanboard/kanboard:v1.2.24",
+        default: "kanboard/kanboard:v1.2.26",
       },
     },
   },

--- a/templates/kanboard/meta.yaml
+++ b/templates/kanboard/meta.yaml
@@ -35,4 +35,4 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: kanboard/kanboard:v1.2.24
+      default: kanboard/kanboard:v1.2.26

--- a/templates/komga/meta.ts
+++ b/templates/komga/meta.ts
@@ -26,7 +26,7 @@ export const meta = {
       appServiceImage: {
         type: "string",
         title: "App Service Image",
-        default: "gotson/komga:0.157.5",
+        default: "gotson/komga:0.160.0",
       },
     },
   },

--- a/templates/komga/meta.yaml
+++ b/templates/komga/meta.yaml
@@ -29,4 +29,4 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: gotson/komga:0.157.5
+      default: gotson/komga:0.160.0

--- a/templates/lychee/meta.ts
+++ b/templates/lychee/meta.ts
@@ -34,7 +34,7 @@ export const meta = {
       appServiceImage: {
         type: "string",
         title: "App Service Image",
-        default: "lycheeorg/lychee:v4.6.1",
+        default: "lycheeorg/lychee:v4.7.0",
       },
       databaseType: {
         type: "string",

--- a/templates/lychee/meta.yaml
+++ b/templates/lychee/meta.yaml
@@ -34,7 +34,7 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: lycheeorg/lychee:v4.6.1
+      default: lycheeorg/lychee:v4.7.0
     databaseType:
       type: string
       title: Database Type

--- a/templates/mattermost/meta.ts
+++ b/templates/mattermost/meta.ts
@@ -44,7 +44,7 @@ export const meta = {
       appServiceImage: {
         type: "string",
         title: "App Service Image",
-        default: "mattermost/mattermost-team-edition:release-7.5.1",
+        default: "mattermost/mattermost-team-edition:release-7.7",
       },
       databaseServiceName: {
         type: "string",

--- a/templates/mattermost/meta.yaml
+++ b/templates/mattermost/meta.yaml
@@ -45,7 +45,7 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: mattermost/mattermost-team-edition:release-7.5.1
+      default: mattermost/mattermost-team-edition:release-7.7
     databaseServiceName:
       type: string
       title: Database Service Name

--- a/templates/ntfy/meta.ts
+++ b/templates/ntfy/meta.ts
@@ -27,7 +27,7 @@ export const meta = {
       appServiceImage: {
         type: "string",
         title: "App Service Image",
-        default: "binwiederhier/ntfy:v1.29.1",
+        default: "binwiederhier/ntfy:v1.30.1",
       },
     },
   },

--- a/templates/ntfy/meta.yaml
+++ b/templates/ntfy/meta.yaml
@@ -33,4 +33,4 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: binwiederhier/ntfy:v1.29.1
+      default: binwiederhier/ntfy:v1.30.1

--- a/templates/paperlessngx/meta.ts
+++ b/templates/paperlessngx/meta.ts
@@ -36,7 +36,7 @@ export const meta = {
       appServiceImage: {
         type: "string",
         title: "App Service Image",
-        default: "paperlessngx/paperless-ngx:1.9.2",
+        default: "paperlessngx/paperless-ngx:1.11.3",
       },
       redisServiceName: {
         type: "string",

--- a/templates/paperlessngx/meta.yaml
+++ b/templates/paperlessngx/meta.yaml
@@ -34,7 +34,7 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: paperlessngx/paperless-ngx:1.9.2
+      default: paperlessngx/paperless-ngx:1.11.3
     redisServiceName:
       type: string
       title: Redis Service Name

--- a/templates/radarr/meta.ts
+++ b/templates/radarr/meta.ts
@@ -27,7 +27,7 @@ export const meta = {
       appServiceImage: {
         type: "string",
         title: "App Service Image",
-        default: "linuxserver/radarr:4.2.4.6635-ls153",
+        default: "linuxserver/radarr:version-4.3.2.6857",
       },
     },
   },

--- a/templates/radarr/meta.yaml
+++ b/templates/radarr/meta.yaml
@@ -31,4 +31,4 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: linuxserver/radarr:4.2.4.6635-ls153
+      default: linuxserver/radarr:version-4.3.2.6857

--- a/templates/restreamer/meta.ts
+++ b/templates/restreamer/meta.ts
@@ -26,7 +26,7 @@ export const meta = {
       appServiceImage: {
         type: "string",
         title: "App Service Image",
-        default: "datarhei/restreamer:2.3.0",
+        default: "datarhei/restreamer:2.4.2",
       },
     },
   },

--- a/templates/restreamer/meta.yaml
+++ b/templates/restreamer/meta.yaml
@@ -29,4 +29,4 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: datarhei/restreamer:2.3.0
+      default: datarhei/restreamer:2.4.2

--- a/templates/sonarr/meta.ts
+++ b/templates/sonarr/meta.ts
@@ -27,7 +27,7 @@ export const meta = {
       appServiceImage: {
         type: "string",
         title: "App Service Image",
-        default: "linuxserver/sonarr:3.0.9.1549",
+        default: "linuxserver/sonarr:version-3.0.9.1549",
       },
     },
   },

--- a/templates/sonarr/meta.yaml
+++ b/templates/sonarr/meta.yaml
@@ -31,4 +31,4 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: linuxserver/sonarr:3.0.9.1549
+      default: linuxserver/sonarr:version-3.0.9.1549

--- a/templates/sshwifty/meta.ts
+++ b/templates/sshwifty/meta.ts
@@ -23,7 +23,7 @@ export const meta = {
       appServiceImage: {
         type: "string",
         title: "App Service Image",
-        default: "niruix/sshwifty:0.2.31-beta-release",
+        default: "niruix/sshwifty:0.2.32-beta-release",
       },
     },
   },

--- a/templates/sshwifty/meta.yaml
+++ b/templates/sshwifty/meta.yaml
@@ -27,4 +27,4 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: niruix/sshwifty:0.2.31-beta-release
+      default: niruix/sshwifty:0.2.32-beta-release

--- a/templates/verdaccio/meta.ts
+++ b/templates/verdaccio/meta.ts
@@ -29,7 +29,7 @@ export const meta = {
       appServiceImage: {
         type: "string",
         title: "App Service Image",
-        default: "verdaccio/verdaccio:5.15",
+        default: "verdaccio/verdaccio:5.19.1",
       },
     },
   },

--- a/templates/verdaccio/meta.yaml
+++ b/templates/verdaccio/meta.yaml
@@ -31,4 +31,4 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: verdaccio/verdaccio:5.15
+      default: verdaccio/verdaccio:5.19.1

--- a/templates/vscode-server/meta.ts
+++ b/templates/vscode-server/meta.ts
@@ -33,7 +33,7 @@ export const meta = {
       appServiceImage: {
         type: "string",
         title: "App Service Image",
-        default: "lscr.io/linuxserver/code-server:4.8.1-ls138",
+        default: "lscr.io/linuxserver/code-server:4.9.1-ls148",
       },
     },
   },

--- a/templates/vscode-server/meta.yaml
+++ b/templates/vscode-server/meta.yaml
@@ -33,4 +33,4 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: lscr.io/linuxserver/code-server:4.8.1-ls138
+      default: lscr.io/linuxserver/code-server:4.9.1-ls148

--- a/templates/weblate/meta.ts
+++ b/templates/weblate/meta.ts
@@ -42,7 +42,7 @@ export const meta = {
       appServiceImage: {
         type: "string",
         title: "App Service Image",
-        default: "weblate/weblate:4.14.2-1",
+        default: "weblate/weblate:4.15.1-1",
       },
       databaseServiceName: {
         type: "string",

--- a/templates/weblate/meta.yaml
+++ b/templates/weblate/meta.yaml
@@ -39,7 +39,7 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: weblate/weblate:4.14.2-1
+      default: weblate/weblate:4.15.1-1
     databaseServiceName:
       type: string
       title: Database Service Name


### PR DESCRIPTION
**Updates: 2023-01-23**

All the updates from the [Easypanel-Community Team](https://github.com/Easypanel-Community)

Thanks to @deiucanta for Allowing Multi-Template Updates (Saves on the PRs)

- Jellyseerr to 1.3.0
- Kanboard to 1.2.26
- Komga to 0.160.0
- Lychee to 4.7.0
- Mattermost to release-7.7
- Ntfy to 1.30.1
- Paperless-Ngx to 1.11.3
- Radarr to version-4.3.2.6857
- Restreamer to 2.4.2
- Sonarr to version-3.0.9.1549
- SShwifty to 0.2.32-beta-release
- Verdaccio to 5.19.1
- VS Code Server to 4.9.1-ls148
- Weblate to 4.15.1-1