### PR TITLE
Update index.ts

### DIFF
--- a/templates/outline/index.ts
+++ b/templates/outline/index.ts
@@ -45,7 +45,7 @@ export function generate(input: Input): Output {
         image: input.appServiceImage,
       },
       deploy: {
-        command: `sh -c "yarn sequelize:migrate --env=production-ssl-disabled && yarn start --env=production-ssl-disabled"`,
+        command: `sh -c "yarn db:migrate --env=production-ssl-disabled && yarn start --env=production-ssl-disabled"`,
       },
       proxy: {
         port: 3000,


### PR DESCRIPTION
Need to update the command from sequelize:migrate to to db:migrate for support latest version. You can refer the official release from outline github https://github.com/outline/outline/releases.

![image](https://user-images.githubusercontent.com/105085586/221180714-5a51057a-981a-4dc2-8f8e-7a34e8614b0a.png)
