### PR TITLE
fixed rallly links

### DIFF
--- a/templates/rallly/meta.yaml
+++ b/templates/rallly/meta.yaml
@@ -7,11 +7,11 @@ changeLog:
     description: first release
 links:
   - label: Website
-    url: https://fider.io
+    url: https://rallly.co
   - label: Documentation
-    url: https://fider.io/docs
+    url: https://github.com/lukevella/rallly-selfhosted
   - label: Github
-    url: https://github.com/getfider/fider
+    url: https://github.com/lukevella/rallly
 contributors:
   - name: Supernova3339
     url: https://github.com/Supernova3339


### PR DESCRIPTION
Rallly links were incorrect and pointing to fider.io docs and website.