### PR TITLE
Chatwoot Sideqik container access to volumes fixed. 

### DIFF
--- a/templates/chatwoot/index.ts
+++ b/templates/chatwoot/index.ts
@@ -78,6 +78,18 @@ export function generate(input: Input): Output {
       deploy: {
         command: "bundle exec sidekiq -C config/sidekiq.yml",
       },
+      mounts: [
+        {
+          type: "bind",
+          hostPath: `/etc/easypanel/projects/$(PROJECT_NAME)/${input.appServiceName}/volumes/data`,
+          mountPath: "/data/storage",
+        },
+        {
+          type: "bind",
+          hostPath: `/etc/easypanel/projects/$(PROJECT_NAME)/${input.appServiceName}/volumes/app`,
+          mountPath: "/app/storage",
+        },
+      ],
     },
   });
 

--- a/templates/chatwoot/index.ts
+++ b/templates/chatwoot/index.ts
@@ -81,11 +81,6 @@ export function generate(input: Input): Output {
       mounts: [
         {
           type: "bind",
-          hostPath: `/etc/easypanel/projects/$(PROJECT_NAME)/${input.appServiceName}/volumes/data`,
-          mountPath: "/data/storage",
-        },
-        {
-          type: "bind",
           hostPath: `/etc/easypanel/projects/$(PROJECT_NAME)/${input.appServiceName}/volumes/app`,
           mountPath: "/app/storage",
         },


### PR DESCRIPTION
Chatwoot uses a sideqik container, that was having issues while accessing the data produced within the chatwoot volumes app and data directory. Fixed now. 