### PR TITLE
Fixed keycloak template for reverse proxy

### DIFF
--- a/templates/keycloak/index.ts
+++ b/templates/keycloak/index.ts
@@ -22,6 +22,7 @@ export function generate(input: Input): Output {
         `PROXY_ADDRESS_FORWARDING=true`,
         `KC_HTTP_ENABLED=false`,
         `KC_FEATURES=docker`,
+        `KC_PROXY_HEADERS=xforwarded`
       ].join("\n"),
       source: {
         type: "image",


### PR DESCRIPTION
fixed an issue where it needed to forward headers on fresh creation of template. https://www.keycloak.org/server/reverseproxy