### PR TITLE
Update meta.yaml

### DIFF
--- a/templates/photoprism/meta.yaml
+++ b/templates/photoprism/meta.yaml
@@ -45,7 +45,7 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: photoprism/photoprism:240915
+      default: photoprism/photoprism:latest
     photoprismAdminUser:
       type: string
       title: Username


### PR DESCRIPTION
The current version of Photo Prism in Easy Panel is outdated by two versions.  Current release version is 26.0.6