### PR TITLE
Update index.ts

### DIFF
--- a/templates/ollama/index.ts
+++ b/templates/ollama/index.ts
@@ -18,6 +18,11 @@ export function generate(input: Input): Output {
           name: "data",
           mountPath: "/data",
         },
+        {
+          type: "volume",
+          name: "ollama",
+          mountPath: "/root/.ollama",
+        },        
       ],
     },
   });


### PR DESCRIPTION
When the Ollama service is restarted, the installed models are lost because the location where they are installed is not persisted on the volumes. 

To prevent this it is necessary to persist the "ollama" volume to the path "/root/.ollama"