### PR TITLE
Upgrade PostgreSQL to Support Chatwoot v4+

### DIFF
--- a/templates/chatwoot/index.ts
+++ b/templates/chatwoot/index.ts
@@ -102,15 +102,12 @@ services.push({
     serviceName: input.databaseServiceName,
     image: "postgres:12",
     password: randomPasswordPostgres,
-    init: [
-      "apt-get update",
-      "apt-get install -y postgresql-server-dev-12 git build-essential",
-      "git clone --branch v0.5.0 https://github.com/pgvector/pgvector.git",
-      "cd pgvector && make && make install",
-      "psql -U postgres -c \"CREATE EXTENSION vector;\""
-    ]
-  }
+    deploy: {
+      command: "apt-get update && apt-get install -y postgresql-server-dev-12 git build-essential && git clone --branch v0.5.0 https://github.com/pgvector/pgvector.git && cd pgvector && make && make install && psql -U postgres -c \"CREATE EXTENSION vector;\""
+    }
+  },
 });
+
 
 
   return { services };

--- a/templates/chatwoot/index.ts
+++ b/templates/chatwoot/index.ts
@@ -96,14 +96,20 @@ export function generate(input: Input): Output {
     },
   });
 
-  services.push({
-    type: "postgres",
-    data: {
-      serviceName: input.databaseServiceName,
-      image: "postgres:12",
-      password: randomPasswordPostgres,
-    },
-  });
+services.push({
+  type: "postgres",
+  data: {
+    serviceName: input.databaseServiceName,
+    image: "postgres:12",
+    password: randomPasswordPostgres,
+    deploy: {
+      command: [
+        "docker-entrypoint.sh postgres && apt-get update && apt-get install -y postgresql-server-dev-12 git build-essential && git clone --branch v0.5.0 https://github.com/pgvector/pgvector.git && cd pgvector && make && make install && psql -U postgres -c \"CREATE EXTENSION vector;\""
+      ]
+    }
+  },
+});
+
 
   return { services };
 }

--- a/templates/chatwoot/index.ts
+++ b/templates/chatwoot/index.ts
@@ -103,13 +103,10 @@ services.push({
     image: "postgres:12",
     password: randomPasswordPostgres,
     deploy: {
-      command: [
-        "docker-entrypoint.sh postgres && apt-get update && apt-get install -y postgresql-server-dev-12 git build-essential && git clone --branch v0.5.0 https://github.com/pgvector/pgvector.git && cd pgvector && make && make install && psql -U postgres -c \"CREATE EXTENSION vector;\""
-      ]
+      command: "docker-entrypoint.sh postgres && apt-get update && apt-get install -y postgresql-server-dev-12 git build-essential && git clone --branch v0.5.0 https://github.com/pgvector/pgvector.git && cd pgvector && make && make install && psql -U postgres -c \"CREATE EXTENSION vector;\""
     }
   },
 });
-
 
   return { services };
 }

--- a/templates/chatwoot/index.ts
+++ b/templates/chatwoot/index.ts
@@ -102,11 +102,16 @@ services.push({
     serviceName: input.databaseServiceName,
     image: "postgres:12",
     password: randomPasswordPostgres,
-    deploy: {
-      command: "docker-entrypoint.sh postgres && apt-get update && apt-get install -y postgresql-server-dev-12 git build-essential && git clone --branch v0.5.0 https://github.com/pgvector/pgvector.git && cd pgvector && make && make install && psql -U postgres -c \"CREATE EXTENSION vector;\""
-    }
-  },
+    init: [
+      "apt-get update",
+      "apt-get install -y postgresql-server-dev-12 git build-essential",
+      "git clone --branch v0.5.0 https://github.com/pgvector/pgvector.git",
+      "cd pgvector && make && make install",
+      "psql -U postgres -c \"CREATE EXTENSION vector;\""
+    ]
+  }
 });
+
 
   return { services };
 }

--- a/templates/chatwoot/index.ts
+++ b/templates/chatwoot/index.ts
@@ -96,19 +96,14 @@ export function generate(input: Input): Output {
     },
   });
 
-services.push({
-  type: "postgres",
-  data: {
-    serviceName: input.databaseServiceName,
-    image: "postgres:12",
-    password: randomPasswordPostgres,
-    deploy: {
-      command: "apt-get update && apt-get install -y postgresql-server-dev-12 git build-essential && git clone --branch v0.5.0 https://github.com/pgvector/pgvector.git && cd pgvector && make && make install && psql -U postgres -c \"CREATE EXTENSION vector;\""
-    }
-  },
-});
-
-
+  services.push({
+    type: "postgres",
+    data: {
+      serviceName: input.databaseServiceName,
+      image: "ankane/pgvector:v0.5.1",
+      password: randomPasswordPostgres,
+    },
+  });
 
   return { services };
 }


### PR DESCRIPTION
This pull request introduces changes to upgrade PostgreSQL to ensure compatibility with Chatwoot version 4 or higher. The following modifications have been made:

Key Changes:
Updated Image:

The PostgreSQL image has been updated to ankane/pgvector:v0.5.1, which includes the necessary dependencies and pgvector extension pre-installed. This image supports pgvector using PostgreSQL 15 or higher.

PostgreSQL Configuration:

Creates the pgvector extension within the PostgreSQL database using the updated image, ensuring compatibility with Chatwoot v4+.

These updates ensure that PostgreSQL is properly configured and compatible with the latest versions of Chatwoot, enhancing the overall user experience and system capabilities.

Please review and approve these changes to integrate support for Chatwoot v4+.