### PR TITLE
Fixed the Alltube Version Error

### DIFF
--- a/templates/alltube/meta.yaml
+++ b/templates/alltube/meta.yaml
@@ -13,6 +13,8 @@ instructions: null
 changeLog:
   - date: 2023-07-11
     description: First Release
+  - date: 2025-07-03
+    description: Fixed the streaming issue and python version updated.
 links:
   - label: Github
     url: https://github.com/Rudloff/alltube
@@ -21,6 +23,8 @@ links:
 contributors:
   - name: Berk Sümbül
     url: https://berksmbl.com
+  - name: Ahson Shaikh
+    url: https://github.com/Ahson-Shaikh
 schema:
   type: object
   required:
@@ -50,7 +54,7 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: dnomd343/alltube:latest
+      default: dockeriddonuts/alltube:2.0
 benefits:
   - title: Easy Video Downloading
     description:


### PR DESCRIPTION
The Alltube Application has been archived by the maintainer. There were errors with the Python Library being using inside the container and the version update was also necessary. I couldn't find any updated one, so fixed the error in the code and rebuild the image. 