### PR TITLE
Fixed moodle template

### DIFF
--- a/templates/moodle/index.ts
+++ b/templates/moodle/index.ts
@@ -8,6 +8,32 @@ export function generate(input: Input): Output {
   services.push({
     type: "app",
     data: {
+      serviceName: `${input.appServiceName}-db`,
+      source: {
+        type: "image",
+        image: "bitnami/mariadb:latest",
+      },
+      env: [
+        "ALLOW_EMPTY_PASSWORD=yes",
+        `MARIADB_USER=mariadb`,
+        `MARIADB_PASSWORD=${databasePassword}`,
+        `MARIADB_DATABASE=$(PROJECT_NAME)`,
+        "MARIADB_CHARACTER_SET=utf8mb4",
+        "MARIADB_COLLATE=utf8mb4_unicode_ci",
+      ].join("\n"),
+      mounts: [
+        {
+          type: "volume",
+          name: "mariadb-data",
+          mountPath: "/bitnami/mariadb",
+        },
+      ],
+    },
+  });
+
+  services.push({
+    type: "app",
+    data: {
       serviceName: input.appServiceName,
       env: [
         `MOODLE_DATABASE_HOST=$(PROJECT_NAME)_${input.appServiceName}-db`,
@@ -26,15 +52,13 @@ export function generate(input: Input): Output {
           port: 8080,
         },
       ],
-    },
-  });
-
-  services.push({
-    type: "mariadb",
-    data: {
-      serviceName: `${input.appServiceName}-db`,
-      password: databasePassword,
-      image: "docker.io/bitnami/mariadb:latest",
+      mounts: [
+        {
+          type: "volume",
+          name: "moodle-data",
+          mountPath: "/bitnami/moodle",
+        },
+      ],
     },
   });
 

--- a/templates/moodle/meta.yaml
+++ b/templates/moodle/meta.yaml
@@ -18,6 +18,8 @@ changeLog:
     description: First Release
   - date: 2025-02-28
     description: Version bumped to 4.5.2
+  - date: 2025-07-10
+    description: Version bumped to 5.0.0
 links:
   - label: Website
     url: https://moodle.org/
@@ -41,7 +43,7 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: docker.io/bitnami/moodle:4.5.2
+      default: docker.io/bitnami/moodle:5.0.0
 benefits:
   - title: Personalized Learning Experience
     description:


### PR DESCRIPTION
We changed the Moodle from managed EP database to an app service, to have better flexibility at changing some configuration required for the moodle installation. 

These two envs were needed to make the installation proceed, otherwise, the moodle container kept restarting.  

        "MARIADB_CHARACTER_SET=utf8mb4",
        "MARIADB_COLLATE=utf8mb4_unicode_ci",

Tested and updated.     
    