### PR TITLE
Update Directus template to support MySQL 8 and v11.10.2

### DIFF
--- a/templates/directus/index.ts
+++ b/templates/directus/index.ts
@@ -73,7 +73,7 @@ export function generate(input: Input): Output {
       type: "mysql",
       data: {
         serviceName: input.databaseServiceName,
-        image: "mysql:5",
+        image: "mysql:8",
         password: databasePassword,
       },
     });

--- a/templates/directus/meta.yaml
+++ b/templates/directus/meta.yaml
@@ -17,6 +17,10 @@ changeLog:
     description: first release
   - date: 2025-05-26
     description: Version bumped to 11.7.2
+  - date: 2025-08-13
+    description: 
+      Version bumped to 11.10.2
+      MySQL 8 support added
 links:
   - label: Website
     url: https://directus.io/
@@ -31,6 +35,8 @@ contributors:
     url: https://github.com/deiucanta
   - name: Ahson Shaikh
     url: https://github.com/Ahson-Shaikh
+  - name: Abhinay M
+    url: https://github.com/AbhinayMe
 schema:
   type: object
   required:
@@ -49,7 +55,7 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: directus/directus:11.7.2
+      default: directus/directus:11.10.2
     adminEmail:
       type: string
       title: Admin Email


### PR DESCRIPTION
This pull request updates the Directus template to support MySQL 8 and bumps the default Directus version to 11.10.2. It also adds a new contributor and updates the changelog to reflect these changes.

**Platform and version updates:**

* Changed the database image from `mysql:5` to `mysql:8` in `index.ts` to add support for MySQL 8.
* Updated the default `appServiceImage` in the schema from `directus/directus:11.7.2` to `directus/directus:11.10.2` in `meta.yaml`.

**Documentation and metadata:**

* Added a changelog entry for the version bump to 11.10.2 and MySQL 8 support in `meta.yaml`.
* Added a new contributor, Abhinay M, to the contributors list in `meta.yaml`.