### PR TITLE
Updated Formbricks to Latest version and Caching mechanism

### DIFF
--- a/templates/formbricks/index.ts
+++ b/templates/formbricks/index.ts
@@ -11,8 +11,10 @@ export function generate(input: Input): Output {
   const databasePassword = randomPassword();
   const nextAuthSecret = randomString(32);
   const encryptionKey = randomString(32);
+  const redisPassword = randomPassword();
   const appEnv = [
-    `DATABASE_URL=postgres://postgres:${databasePassword}@$(PROJECT_NAME)_${input.databaseServiceName}:5432/$(PROJECT_NAME)`,
+    `DATABASE_URL=postgres://postgres:${databasePassword}@$(PROJECT_NAME)_${input.appServiceName}-db:5432/$(PROJECT_NAME)`,
+    `REDIS_URL=redis://default:${redisPassword}@$(PROJECT_NAME)_${input.appServiceName}-redis:6379`,
     `NEXTAUTH_SECRET=${nextAuthSecret}`,
     `ENCRYPTION_KEY=${encryptionKey}`,
     `WEBAPP_URL=https://$(PRIMARY_DOMAIN)`,
@@ -38,7 +40,7 @@ export function generate(input: Input): Output {
   services.push({
     type: "app",
     data: {
-      serviceName: "formbricks-app",
+      serviceName: input.appServiceName,
       source: { type: "image", image: input.appServiceImage },
       domains: [
         {
@@ -60,8 +62,17 @@ export function generate(input: Input): Output {
   services.push({
     type: "postgres",
     data: {
-      serviceName: input.databaseServiceName,
+      serviceName: `${input.appServiceName}-db`,
       password: databasePassword,
+      image: input.databaseServiceImage,
+    },
+  });
+
+  services.push({
+    type: "redis",
+    data: {
+      serviceName: `${input.appServiceName}-redis`,
+      password: redisPassword,
     },
   });
 

--- a/templates/formbricks/meta.yaml
+++ b/templates/formbricks/meta.yaml
@@ -25,17 +25,22 @@ contributors:
 schema:
   type: object
   required:
+    - appServiceName
     - appServiceImage
-    - databaseServiceName
+    - databaseServiceImage
   properties:
+    appServiceName:
+      type: string
+      title: App Service Name
+      default: formbricks
     appServiceImage:
       type: string
       title: App Service Image
       default: ghcr.io/formbricks/formbricks:v3.16.0
-    databaseServiceName:
+    databaseServiceImage:
       type: string
-      title: Database Service Name
-      default: formbricks-db
+      title: Database Service Image
+      default: pgvector/pgvector:pg17
     enterpriseLicenseKey:
       type: string
       title: Enterprise License Key


### PR DESCRIPTION
We have updated the Formbricks template. The latest version was having issues while migration. Upon investigation, it was found that the database is now using the pgvector extention enabled Docker image instead of normal postgress image. Additionally, redis was also required. 