### PR TITLE
Update MinIO service image default value from Bitnami to Minio

### DIFF
--- a/templates/cap/meta.yaml
+++ b/templates/cap/meta.yaml
@@ -42,7 +42,7 @@ schema:
     minioServiceImage:
       type: string
       title: MinIO Service Image
-      default: bitnami/minio:latest
+      default: minio/minio:latest
     minioAccessKey:
       type: string
       title: MinIO Access Key


### PR DESCRIPTION
Bitnami is no longer publishing on `bitnami/minio` moved to `minio/minio`