### PR TITLE
Updated Authorizer to v2

### DIFF
--- a/templates/authorizer/index.ts
+++ b/templates/authorizer/index.ts
@@ -1,21 +1,24 @@
-import { Output, randomPassword, Services } from "~templates-utils";
+import {
+  Output,
+  randomPassword,
+  randomString,
+  Services,
+} from "~templates-utils";
 import { Input } from "./meta";
 
 export function generate(input: Input): Output {
   const services: Services = [];
   const databasePassword = randomPassword();
   const redisPassword = randomPassword();
+  const jwtSecret = randomString(32);
+  const adminSecret = randomString(32);
+  const clientId = randomString(16);
+  const clientSecret = randomString(32);
 
   services.push({
     type: "app",
     data: {
       serviceName: input.appServiceName,
-      env: [
-        `ENV=production`,
-        `DATABASE_URL=postgres://postgres:${databasePassword}@$(PROJECT_NAME)_${input.databaseServiceName}:5432/$(PROJECT_NAME)?sslmode=disable`,
-        `DATABASE_TYPE=postgres`,
-        `REDIS_URL=redis://default:${redisPassword}@$(PROJECT_NAME)_${input.redisServiceName}:6379`,
-      ].join("\n"),
       source: {
         type: "image",
         image: input.appServiceImage,
@@ -26,6 +29,14 @@ export function generate(input: Input): Output {
           port: 8080,
         },
       ],
+      env: [
+        `DATABASE_URL=postgres://postgres:${databasePassword}@$(PROJECT_NAME)_${input.databaseServiceName}:5432/$(PROJECT_NAME)?sslmode=disable`,
+        `REDIS_URL=redis://default:${redisPassword}@$(PROJECT_NAME)_${input.redisServiceName}:6379`,
+        `DOMAIN=https://$(EASYPANEL_DOMAIN)`,
+      ].join("\n"),
+      deploy: {
+        command: `./authorizer --database-type=postgres --database-url="$DATABASE_URL" --redis-url="$REDIS_URL" --jwt-type=HS256 --jwt-secret="${jwtSecret}" --admin-secret="${adminSecret}" --client-id="${clientId}" --client-secret="${clientSecret}" --allowed-origins="$DOMAIN" --env=production`,
+      },
     },
   });
 

--- a/templates/authorizer/meta.yaml
+++ b/templates/authorizer/meta.yaml
@@ -25,6 +25,8 @@ changeLog:
     description: Version bumped to 1.3.8
   - date: 2024-09-28
     description: Update to 1.4.4
+  - date: 2026-05-15
+    description: Major update to 2.2.1; v2 uses CLI flags instead of env vars
 links:
   - label: Website
     url: https://authorizer.dev
@@ -54,7 +56,7 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: lakhansamani/authorizer:1.4.4
+      default: lakhansamani/authorizer:2.2.1
     databaseServiceName:
       type: string
       title: Database Service Name


### PR DESCRIPTION
**index.ts**:
  - Removed the old v1 env vars (DATABASE_TYPE, DATABASE_URL, REDIS_URL, ENV)
  - Added deploy.command that invokes ./authorizer with all required v2 CLI flags
  - Connection strings (DATABASE_URL, REDIS_URL, DOMAIN) are still set as env vars so Easypanel can substitute $(PROJECT_NAME)
   and $(EASYPANEL_DOMAIN) at runtime — the shell then expands them into the flags
  - Secrets (--jwt-secret, --admin-secret, --client-id, --client-secret) are generated with randomString and embedded directly
  - Added --allowed-origins to fix the CSRF warning too

  **meta.yaml:** 1.4.4 → 2.2.1