### PR TITLE
Updated UptimeKuma to 2.3.2

### DIFF
--- a/templates/uptimekuma/meta.yaml
+++ b/templates/uptimekuma/meta.yaml
@@ -23,6 +23,8 @@ changeLog:
     description: Version bumped to 2.1.0-beta.0
   - date: 2026-02-24
     description: Version bumped to 2.1.3
+  - date: 2026-05-17
+    description: Version bumped to 2.3.2
 links:
   - label: Website
     url: https://uptime.kuma.pet
@@ -48,7 +50,7 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: louislam/uptime-kuma:2.1.3
+      default: louislam/uptime-kuma:2.3.2
 benefits:
   - title: Easy-to-use monitoring tool
     description:


### PR DESCRIPTION
Bumps `louislam/uptime-kuma` from `2.1.3` to the latest stable [`2.3.2`](https://github.com/louislam/uptime-kuma/releases/tag/2.3.2).

### Changes
- `templates/uptimekuma/meta.yaml`
  - `appServiceImage` default: `louislam/uptime-kuma:2.1.3` → `louislam/uptime-kuma:2.3.2`
  - Added changelog entry for `2026-05-17` — Version bumped to `2.3.2`

### Upstream releases covered (2.1.3 → 2.3.2)
- [2.2.0](https://github.com/louislam/uptime-kuma/releases/tag/2.2.0)
- [2.2.1](https://github.com/louislam/uptime-kuma/releases/tag/2.2.1)
- [2.3.0](https://github.com/louislam/uptime-kuma/releases/tag/2.3.0)
- [2.3.1](https://github.com/louislam/uptime-kuma/releases/tag/2.3.1)
- [2.3.2](https://github.com/louislam/uptime-kuma/releases/tag/2.3.2)

### Notes
- No template config changes required.
  - Container port `3001` unchanged (confirmed in upstream `compose.yaml` and Dockerfile).
  - Data volume `/app/data` unchanged.
  - `UPTIME_KUMA_SQLITE_SINGLE_CONNECTION` introduced in 2.3.0 is optional (Raspberry Pi only) and was reverted to single-connection default in 2.3.2.
- Validated locally with `npm run build` and `npm run prettier`.