### PR TITLE
Add ZeroClaw template

### DIFF
--- a/templates/zeroclaw/index.ts
+++ b/templates/zeroclaw/index.ts
@@ -1,0 +1,37 @@
+import { Output, Services } from "~templates-utils";
+import { Input } from "./meta";
+
+export function generate(input: Input): Output {
+  const services: Services = [];
+
+  services.push({
+    type: "app",
+    data: {
+      serviceName: input.appServiceName,
+      env: [
+        `ZEROCLAW_gateway__allow_public_bind=true`,
+        `ZEROCLAW_gateway__port=42617`,
+        `ZEROCLAW_providers__models__openrouter__default__api_key=${input.apiKey}`,
+      ].join("\n"),
+      source: {
+        type: "image",
+        image: input.appServiceImage,
+      },
+      domains: [
+        {
+          host: `$(EASYPANEL_DOMAIN)`,
+          port: 42617,
+        },
+      ],
+      mounts: [
+        {
+          type: "volume",
+          name: "data",
+          mountPath: "/zeroclaw-data",
+        },
+      ],
+    },
+  });
+
+  return { services };
+}

--- a/templates/zeroclaw/index.ts
+++ b/templates/zeroclaw/index.ts
@@ -4,15 +4,28 @@ import { Input } from "./meta";
 export function generate(input: Input): Output {
   const services: Services = [];
 
+  const providerEnvMap: Record<string, string> = {
+    openrouter: "ZEROCLAW_providers__models__openrouter__default__api_key",
+    openai: "ZEROCLAW_providers__models__openai__default__api_key",
+    anthropic: "ZEROCLAW_providers__models__anthropic__default__api_key",
+    ollama: "",
+  };
+
+  const envLines = [
+    `ZEROCLAW_gateway__allow_public_bind=true`,
+    `ZEROCLAW_gateway__port=42617`,
+  ];
+
+  if (input.provider !== "ollama" && input.apiKey) {
+    const envKey = providerEnvMap[input.provider] || providerEnvMap.openrouter;
+    envLines.push(`${envKey}=${input.apiKey}`);
+  }
+
   services.push({
     type: "app",
     data: {
       serviceName: input.appServiceName,
-      env: [
-        `ZEROCLAW_gateway__allow_public_bind=true`,
-        `ZEROCLAW_gateway__port=42617`,
-        `ZEROCLAW_providers__models__openrouter__default__api_key=${input.apiKey}`,
-      ].join("\n"),
+      env: envLines.join("\n"),
       source: {
         type: "image",
         image: input.appServiceImage,

--- a/templates/zeroclaw/meta.yaml
+++ b/templates/zeroclaw/meta.yaml
@@ -1,13 +1,18 @@
 name: ZeroClaw
-description:
+description: |
   ZeroClaw is a fast, small, and fully autonomous AI personal assistant
-  infrastructure. Deploy anywhere, swap any provider. It supports any OS
-  and any platform — a self-hosted AI agent gateway with a built-in web
-  dashboard for managing LLM providers, models, and conversations.
-instructions: |-
-  After deployment, you need to provide an LLM API key (e.g. OpenRouter,
-  Anthropic, or OpenAI) to start using ZeroClaw. The gateway will be
-  available on port 42617.
+  infrastructure built in 100% Rust. Deploy anywhere, swap anything.
+  Connect any LLM provider (OpenRouter, OpenAI, Anthropic, Ollama) and
+  interact via a built-in web dashboard, REST API, or WebSocket gateway.
+  Supports multi-channel communication (Discord, Telegram, Matrix, Slack,
+  WhatsApp, Nostr, Lark), persistent memory, scheduled tasks, and
+  autonomous tool use.
+instructions: |
+  After deployment, access the ZeroClaw gateway at the assigned domain
+  on port 42617. Set your LLM provider API key in the environment
+  variables. The default provider is OpenRouter — get a key at
+  https://openrouter.ai/keys. You can switch to OpenAI, Anthropic,
+  or a local Ollama instance by changing the provider variable.
 changeLog:
   - date: 2026-05-21
     description: First release
@@ -15,18 +20,20 @@ links:
   - label: Website
     url: https://zeroclaw.com
   - label: Documentation
-    url: https://github.com/zeroclaw-labs/zeroclaw
-  - label: GitHub
+    url: https://github.com/zeroclaw-labs/zeroclaw#readme
+  - label: Github
     url: https://github.com/zeroclaw-labs/zeroclaw
 contributors:
-  - name: ZeroClaw Labs
-    url: https://github.com/zeroclaw-labs
+  - name: theonlyhennygod
+    url: https://github.com/theonlyhennygod
+logo: zeroclaw.png
 schema:
   type: object
   required:
     - appServiceName
     - appServiceImage
     - apiKey
+    - provider
   properties:
     appServiceName:
       type: string
@@ -38,42 +45,49 @@ schema:
       default: ghcr.io/zeroclaw-labs/zeroclaw:latest
     apiKey:
       type: string
-      title: LLM API Key
-      description: API key for your LLM provider (OpenRouter, Anthropic, or OpenAI)
+      title: LLM Provider API Key
+      description: Your API key for the selected LLM provider (e.g. OpenRouter, OpenAI, Anthropic)
+      default: ""
+    provider:
+      type: string
+      title: LLM Provider
+      default: openrouter
+      oneOf:
+        - enum:
+            - openrouter
+          title: OpenRouter
+        - enum:
+            - openai
+          title: OpenAI
+        - enum:
+            - anthropic
+          title: Anthropic
+        - enum:
+            - ollama
+          title: Ollama (Local)
 benefits:
-  - title: Self-Hosted AI Agent
-    description:
-      Run your own AI assistant infrastructure with full control over data
-      and privacy. No third-party cloud dependency required.
-  - title: Multi-Provider Support
-    description:
-      Swap between OpenRouter, Anthropic, OpenAI, and more without changing
-      your setup. One gateway, any provider.
-  - title: Lightweight and Fast
-    description:
-      Built in Rust for minimal resource usage. Runs on as little as 32MB RAM
-      with a single Docker container.
-features:
-  - title: AI Agent Gateway
-    description:
-      A unified API gateway for managing LLM conversations and tool use
-      across multiple providers.
-  - title: Web Dashboard
-    description:
-      Built-in web UI for managing providers, models, conversations, and
-      monitoring usage.
-  - title: Docker-First Deployment
-    description:
-      Single container, single volume, single port. Deploy with one command
-      on any Docker-compatible platform.
+  - title: Lightning Fast
+    description: Built in 100% Rust with optimized binary size (~15MB). Starts in milliseconds, runs on minimal resources.
+  - title: Deploy Anywhere
+    description: Runs on Linux (amd64/arm64), macOS, Windows, Raspberry Pi, and Android. Multi-arch Docker images included.
   - title: Provider Agnostic
-    description:
-      Supports OpenRouter, Anthropic, OpenAI, and custom endpoints. Switch
-      providers without redeploying.
+    description: Swap between OpenRouter, OpenAI, Anthropic, or local Ollama with a single environment variable change.
+features:
+  - title: Web Dashboard
+    description: Built-in web UI for chatting with your AI assistant, accessible via the gateway port.
+  - title: Multi-Channel
+    description: Connect to Discord, Telegram, Matrix, Slack, WhatsApp, Nostr, Lark, and more simultaneously.
+  - title: Persistent Memory
+    description: SQLite-backed memory and conversation history that survives restarts.
+  - title: Autonomous Tools
+    description: File operations, web search, code execution, git operations, and custom skill creation.
+  - title: Scheduled Tasks
+    description: Built-in cron system for recurring autonomous tasks.
+  - title: REST & WebSocket API
+    description: Full gateway API for programmatic access and real-time streaming.
 tags:
   - AI
-  - Agent
-  - LLM
-  - Automation
   - Self-Hosted
-  - Open Source
+  - Chatbot
+  - Agent
+  - Assistant

--- a/templates/zeroclaw/meta.yaml
+++ b/templates/zeroclaw/meta.yaml
@@ -1,0 +1,79 @@
+name: ZeroClaw
+description:
+  ZeroClaw is a fast, small, and fully autonomous AI personal assistant
+  infrastructure. Deploy anywhere, swap any provider. It supports any OS
+  and any platform — a self-hosted AI agent gateway with a built-in web
+  dashboard for managing LLM providers, models, and conversations.
+instructions: |-
+  After deployment, you need to provide an LLM API key (e.g. OpenRouter,
+  Anthropic, or OpenAI) to start using ZeroClaw. The gateway will be
+  available on port 42617.
+changeLog:
+  - date: 2026-05-21
+    description: First release
+links:
+  - label: Website
+    url: https://zeroclaw.com
+  - label: Documentation
+    url: https://github.com/zeroclaw-labs/zeroclaw
+  - label: GitHub
+    url: https://github.com/zeroclaw-labs/zeroclaw
+contributors:
+  - name: ZeroClaw Labs
+    url: https://github.com/zeroclaw-labs
+schema:
+  type: object
+  required:
+    - appServiceName
+    - appServiceImage
+    - apiKey
+  properties:
+    appServiceName:
+      type: string
+      title: App Service Name
+      default: zeroclaw
+    appServiceImage:
+      type: string
+      title: App Service Image
+      default: ghcr.io/zeroclaw-labs/zeroclaw:latest
+    apiKey:
+      type: string
+      title: LLM API Key
+      description: API key for your LLM provider (OpenRouter, Anthropic, or OpenAI)
+benefits:
+  - title: Self-Hosted AI Agent
+    description:
+      Run your own AI assistant infrastructure with full control over data
+      and privacy. No third-party cloud dependency required.
+  - title: Multi-Provider Support
+    description:
+      Swap between OpenRouter, Anthropic, OpenAI, and more without changing
+      your setup. One gateway, any provider.
+  - title: Lightweight and Fast
+    description:
+      Built in Rust for minimal resource usage. Runs on as little as 32MB RAM
+      with a single Docker container.
+features:
+  - title: AI Agent Gateway
+    description:
+      A unified API gateway for managing LLM conversations and tool use
+      across multiple providers.
+  - title: Web Dashboard
+    description:
+      Built-in web UI for managing providers, models, conversations, and
+      monitoring usage.
+  - title: Docker-First Deployment
+    description:
+      Single container, single volume, single port. Deploy with one command
+      on any Docker-compatible platform.
+  - title: Provider Agnostic
+    description:
+      Supports OpenRouter, Anthropic, OpenAI, and custom endpoints. Switch
+      providers without redeploying.
+tags:
+  - AI
+  - Agent
+  - LLM
+  - Automation
+  - Self-Hosted
+  - Open Source


### PR DESCRIPTION
## Summary
- Adds ZeroClaw as a one-click deployable template
- ZeroClaw is a fast, self-hosted AI agent gateway built in Rust with a built-in web dashboard
- Single container deployment: port 42617, volume at `/zeroclaw-data`, requires an LLM API key

## Template details
- **Image**: `ghcr.io/zeroclaw-labs/zeroclaw:latest`
- **Port**: 42617
- **User inputs**: Service name, image, and LLM API key
- **Resources**: ~32MB RAM minimum, single container, no database required

## Test plan
- [ ] Verify `meta.yaml` schema is valid
- [ ] Verify `index.ts` generates correct service definition
- [ ] Deploy via Easypanel and confirm gateway is accessible