### PR TITLE
feat(opnform): upgrade API and UI images to version 2.0.0

### DIFF
--- a/templates/opnform/index.ts
+++ b/templates/opnform/index.ts
@@ -11,14 +11,18 @@ export function generate(input: Input): Output {
   const postgresPassword = randomPassword();
   const redisPassword = randomPassword();
   const jwtSecret = randomString(64);
+  const frontApiSecret = randomString(64);
   const appKey = randomString(32);
+  const appPublicUrl = `https://$(PROJECT_NAME)-${input.serviceName}-nginx.$(EASYPANEL_HOST)`;
 
   const commonEnv = [
     `APP_NAME=OpnForm`,
     `APP_ENV=production`,
     `APP_KEY=base64:${appKey}`,
-    `APP_DEBUG=true`,
-    `APP_URL=https://$(PROJECT_NAME)-${input.serviceName}-nginx.$(EASYPANEL_HOST)`,
+    `APP_DEBUG=false`,
+    `APP_URL=${appPublicUrl}`,
+    `FRONT_URL=${appPublicUrl}`,
+    `FRONT_API_SECRET=${frontApiSecret}`,
     `SELF_HOSTED=true`,
     `LOG_CHANNEL=errorlog`,
     `LOG_LEVEL=debug`,
@@ -44,7 +48,9 @@ export function generate(input: Input): Output {
     `AWS_BUCKET=null`,
     `JWT_TTL=1440`,
     `JWT_SECRET=${jwtSecret}`,
-    `JWT_SKIP_IP_UA_VALIDATION=true`,
+    `JWT_SKIP_IP_UA_VALIDATION=false`,
+    `PUBLIC_UPLOADS_RATE_LIMIT_PER_MINUTE=30`,
+    `PUBLIC_UPLOADS_RATE_LIMIT_PER_HOUR=300`,
     `OPEN_AI_API_KEY=null`,
     `H_CAPTCHA_SITE_KEY=null`,
     `H_CAPTCHA_SECRET_KEY=null`,
@@ -152,6 +158,8 @@ server {
         `NUXT_PUBLIC_API_BASE=/api`,
         `NUXT_PRIVATE_API_BASE=http://$(PROJECT_NAME)_${input.serviceName}-nginx/api`,
         `NUXT_PUBLIC_ENV=production`,
+        `NUXT_API_SECRET=${frontApiSecret}`,
+        `NUXT_PUBLIC_LICENSE_API_ENDPOINT=https://api.opnform.com`,
         `NUXT_PUBLIC_H_CAPTCHA_SITE_KEY=null`,
         `NUXT_PUBLIC_RE_CAPTCHA_SITE_KEY=null`,
         `NUXT_PUBLIC_ROOT_REDIRECT_URL=null`,

--- a/templates/opnform/meta.yaml
+++ b/templates/opnform/meta.yaml
@@ -16,7 +16,7 @@ changeLog:
   - date: 2026-05-05
     description: Version bumped to 1.13.2
   - date: 2026-06-09
-    description: Version bumped to 2.0.0
+    description: Version bumped to 2.0.1
 links:
   - label: Website
     url: https://opnform.com/
@@ -41,11 +41,11 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: jhumanj/opnform-client:2.0.0
+      default: jhumanj/opnform-client:2.0.1
     apiServiceImage:
       type: string
       title: API Service Image
-      default: jhumanj/opnform-api:2.0.0
+      default: jhumanj/opnform-api:2.0.1
 benefits:
   - title: Easy Form Creation
     description:

--- a/templates/opnform/meta.yaml
+++ b/templates/opnform/meta.yaml
@@ -2,7 +2,7 @@ name: OpnForm
 description:
   OpnForm is an open-source form builder that allows you to create beautiful,
   customizable forms with ease. It provides an intuitive interface for building
-  forms,  collecting submissions, and analyzing data.
+  forms, collecting submissions, and analyzing data.
 instructions: Login using the credentials, admin@opnform.com/password.
 changeLog:
   - date: 2025-05-23
@@ -15,6 +15,8 @@ changeLog:
     description: Version bumped to 1.13.1
   - date: 2026-05-05
     description: Version bumped to 1.13.2
+  - date: 2026-06-09
+    description: Version bumped to 2.0.0
 links:
   - label: Website
     url: https://opnform.com/
@@ -39,11 +41,11 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: jhumanj/opnform-client:1.13.2
+      default: jhumanj/opnform-client:2.0.0
     apiServiceImage:
       type: string
       title: API Service Image
-      default: jhumanj/opnform-api:1.13.2
+      default: jhumanj/opnform-api:2.0.0
 benefits:
   - title: Easy Form Creation
     description:


### PR DESCRIPTION
## Summary
- Bump OpnForm Docker images from `1.13.2` to `2.0.0`
- Add V2 environment variables (FRONT_URL, shared API secret, upload rate limits, license endpoint)
- Set `JWT_SKIP_IP_UA_VALIDATION` and `APP_DEBUG` defaults to `false` for production

## Test plan
- [ ] `npm run build` passes
- [ ] Test template JSON in [playground](https://easypanel-templates.netlify.app/)
- [ ] Deploy on EasyPanel dev instance — all services healthy
- [ ] Complete setup, create a form, verify share URL uses assigned domain
- [ ] Test upgrade from existing 1.x install (backup DB first)

Related: https://github.com/easypanel-io/templates/pull/956