### PR TITLE
Upgrade TwentyCRM due to invalid version

### DIFF
--- a/templates/twenty/index.ts
+++ b/templates/twenty/index.ts
@@ -12,7 +12,7 @@ export function generate(input: Input): Output {
   const redisPassword = randomPassword();
   const appSecret = randomString(32);
 
-  const serverUrl = `https://$(PROJECT_NAME)-${input.appServiceName}.$(EASYPANEL_HOST)`;
+  const serverUrl = `https://$(PRIMARY_DOMAIN)`;
 
   const common_envs = [
     `NODE_PORT=3000`,

--- a/templates/twenty/meta.yaml
+++ b/templates/twenty/meta.yaml
@@ -16,6 +16,8 @@ changeLog:
     description: Update to v1.3.0
   - date: 2026-05-18
     description: Major Update to v2.5.3 with new features and improvements
+  - date: 2025-06-19
+    description: Update to v2.14.3 fixing invalid v2.5.3
 links:
   - label: Website
     url: https://twenty.com/
@@ -39,7 +41,7 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: twentycrm/twenty:v2.5.3
+      default: twentycrm/twenty:v2.14.3
 benefits:
   - title: Modern User Interface
     description:


### PR DESCRIPTION
> The Docker images published 2026-05-18 under tag v2.5.3 (digest sha256:0971ebd23f4b027dcdbffa328a6f568feadbb00ab984bc63f6aed8c1097a9e55) contains a corrupted/empty /app/node_modules/twenty-shared/package.json file (0 bytes).

[Source](https://github.com/twentyhq/twenty/issues/20683)

I successfully run a `twentycrm/twenty:v2.14.3` build with `SERVER_URL=https://$(PRIMARY_DOMAIN)`