### PR TITLE
fix(trigger): add required Redis service and fix DATABASE_HOST port

### DIFF
--- a/templates/trigger/index.ts
+++ b/templates/trigger/index.ts
@@ -4,6 +4,7 @@ import { Input } from "./meta";
 export function generate(input: Input): Output {
   const services: Services = [];
   const databasePassword = randomPassword();
+  const redisPassword = randomPassword();
 
   services.push({
     type: "app",
@@ -27,9 +28,13 @@ export function generate(input: Input): Output {
         `POSTGRES_USER=postgres`,
         `POSTGRES_PASSWORD=${databasePassword}`,
         `POSTGRES_DB=$(PROJECT_NAME)`,
-        `DATABASE_HOST=$(PROJECT_NAME)_${input.databaseServiceName}`,
+        `DATABASE_HOST=$(PROJECT_NAME)_${input.databaseServiceName}:5432`,
         `DATABASE_URL=postgresql://postgres:${databasePassword}@$(PROJECT_NAME)_${input.databaseServiceName}:5432/$(PROJECT_NAME)`,
         `DIRECT_URL=postgresql://postgres:${databasePassword}@$(PROJECT_NAME)_${input.databaseServiceName}:5432/$(PROJECT_NAME)`,
+        `REDIS_HOST=$(PROJECT_NAME)_${input.redisServiceName}`,
+        `REDIS_PORT=6379`,
+        `REDIS_TLS_DISABLED=true`,
+        `REDIS_PASSWORD=${redisPassword}`,
         `NODE_ENV=development`,
         `RUNTIME_PLATFORM=docker-compose`,
 
@@ -47,6 +52,14 @@ export function generate(input: Input): Output {
     data: {
       serviceName: input.databaseServiceName,
       password: databasePassword,
+    },
+  });
+
+  services.push({
+    type: "redis",
+    data: {
+      serviceName: input.redisServiceName,
+      password: redisPassword,
     },
   });
 

--- a/templates/trigger/meta.yaml
+++ b/templates/trigger/meta.yaml
@@ -16,6 +16,10 @@ changeLog:
     description: First Release
   - date: 2025-07-25
     description: Version bumped to v3.3.18
+  - date: 2026-07-04
+    description:
+      Add required Redis service and append the port to DATABASE_HOST so the
+      startup database check passes
 links:
   - label: Website
     url: https://trigger.dev/
@@ -32,6 +36,7 @@ schema:
     - appServiceName
     - appServiceImage
     - databaseServiceName
+    - redisServiceName
   properties:
     appServiceName:
       type: string
@@ -45,6 +50,10 @@ schema:
       type: string
       title: Database Service Name
       default: trigger-db
+    redisServiceName:
+      type: string
+      title: Redis Service Name
+      default: trigger-redis
 benefits:
   - title: Code-First Workflow Automation
     description:


### PR DESCRIPTION
## Problem

The **Trigger** template fails to deploy out of the box. Two independent issues:

### 1. `DATABASE_HOST` is missing the port

Trigger.dev's container entrypoint (`docker/scripts/entrypoint.sh`) does:

```sh
if [ -n "$DATABASE_HOST" ]; then
  scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "database is up"
fi
```

`wait-for-it.sh` requires `host:port`, but the template set `DATABASE_HOST` to the bare host, so deployment loops with:

```
Unknown argument: <project>_trigger-db
Usage: scripts/wait-for-it.sh host:port|url ...
```

Fix: append `:5432` (the sibling `DATABASE_URL`/`DIRECT_URL` already include it).

### 2. No Redis service is provisioned

Trigger.dev v3 requires Redis. The template created only the app + Postgres, so the app crashes on boot:

```
Error: Could not initialize TaskRunConcurrencyTracker because
process.env.REDIS_HOST and process.env.REDIS_PORT are required to be set.
```

Fix: add a `redis` service (following the same pattern as the other templates in this repo) and wire up `REDIS_HOST`, `REDIS_PORT`, `REDIS_TLS_DISABLED`, and `REDIS_PASSWORD`. These values match Trigger.dev's official self-hosting `docker-compose.yml`.

## Changes

- `index.ts`: append `:5432` to `DATABASE_HOST`; add a `redis` service + `REDIS_*` env vars.
- `meta.yaml`: add a `redisServiceName` input (default `trigger-redis`) and a changelog entry.

## Verification

- `npm run build-templates` succeeds.
- `tsc --noEmit` on the template passes (`Input` now includes `redisServiceName`).
- Deployed on a live Easypanel VPS: both errors gone, Trigger.dev boots and runs.