### PR TITLE
Fix Odoo template crashing on startup

### DIFF
--- a/templates/odoo/index.ts
+++ b/templates/odoo/index.ts
@@ -11,6 +11,7 @@ export function generate(input: Input): Output {
       serviceName: `${input.appServiceName}-db`,
       password: databasePassword,
       user: "odoo",
+      databaseName: input.appServiceName,
     },
   });
 
@@ -28,6 +29,9 @@ export function generate(input: Input): Output {
           port: 8069,
         },
       ],
+      deploy: {
+        command: `odoo -d ${input.appServiceName} -i base --without-demo=all`,
+      },
       env: [
         `HOST=$(PROJECT_NAME)_${input.appServiceName}-db`,
         `USER=odoo`,

--- a/templates/odoo/index.ts
+++ b/templates/odoo/index.ts
@@ -10,6 +10,7 @@ export function generate(input: Input): Output {
     data: {
       serviceName: `${input.appServiceName}-db`,
       password: databasePassword,
+      user: "odoo",
     },
   });
 
@@ -29,7 +30,7 @@ export function generate(input: Input): Output {
       ],
       env: [
         `HOST=$(PROJECT_NAME)_${input.appServiceName}-db`,
-        `USER=postgres`,
+        `USER=odoo`,
         `PASSWORD=${databasePassword}`,
         `PORT=5432`,
       ].join("\n"),

--- a/templates/odoo/index.ts
+++ b/templates/odoo/index.ts
@@ -30,14 +30,8 @@ export function generate(input: Input): Output {
         },
       ],
       deploy: {
-        command: `odoo -d ${input.appServiceName} -i base --without-demo=all`,
+        command: `odoo --db_host=$(PROJECT_NAME)_${input.appServiceName}-db --db_port=5432 --db_user=odoo --db_password=${databasePassword} -d ${input.appServiceName} -i base --without-demo=True`,
       },
-      env: [
-        `HOST=$(PROJECT_NAME)_${input.appServiceName}-db`,
-        `USER=odoo`,
-        `PASSWORD=${databasePassword}`,
-        `PORT=5432`,
-      ].join("\n"),
       mounts: [
         {
           type: "volume",

--- a/templates/odoo/meta.yaml
+++ b/templates/odoo/meta.yaml
@@ -61,10 +61,6 @@ schema:
       type: string
       title: App Service Image
       default: odoo:19.0
-    databaseServiceName:
-      type: string
-      title: Database Service Name
-      default: odoo-db
 benefits:
   - title: Integrated Business Management
     description:

--- a/templates/odoo/meta.yaml
+++ b/templates/odoo/meta.yaml
@@ -16,13 +16,13 @@ description:
   accounting, inventory, project management, or any other business application,
   Odoo has got you covered.
 instructions: >-
-  Odoo does not ship with a database pre-created, so the home page will 500 with
-  a "Database ... not initialized" error until you set one up. Visit
-  /web/database/manager on your assigned domain — that page works even while the
-  home page is erroring, since it doesn't need an initialized database. If it
-  lists an existing empty database (e.g. matching your project name), delete it,
-  then use Create Database to set a master password and your first real
-  database. Once that finishes, the home page will load normally.
+  Odoo automatically creates and initializes its own database (with the base
+  module, no demo data) the first time the service boots, so the home page works
+  immediately without a manual database-manager step. If you deployed before
+  2026-07-27 and are stuck on a 500 "Database ... not initialized" error,
+  redeploy the service to pick up this fix — on restart Odoo will create its own
+  valid database alongside the old broken one, and /web/database/selector will
+  let you pick the new, working one.
 changeLog:
   - date: 2023
     description: first release
@@ -30,9 +30,10 @@ changeLog:
     description: Version bumped to 19.0
   - date: 2026-07-27
     description:
-      Fixed crash on startup — Odoo refuses to boot when the database user is
-      named "postgres", so the database user is now "odoo" — and added
-      instructions for setting up the first database via /web/database/manager
+      Fixed crash on startup caused by the database user being named "postgres",
+      and Odoo now auto-creates and initializes its own database on first boot
+      instead of leaving an empty, un-initialized database that 500s on every
+      request
 links:
   - label: Website
     url: https://www.odoo.com

--- a/templates/odoo/meta.yaml
+++ b/templates/odoo/meta.yaml
@@ -32,8 +32,9 @@ changeLog:
     description:
       Fixed crash on startup caused by the database user being named "postgres",
       and Odoo now auto-creates and initializes its own database on first boot
-      instead of leaving an empty, un-initialized database that 500s on every
-      request
+      (with explicit connection flags, since a custom start command bypasses the
+      image's entrypoint.sh) instead of leaving an empty, un-initialized
+      database that 500s on every request
 links:
   - label: Website
     url: https://www.odoo.com

--- a/templates/odoo/meta.yaml
+++ b/templates/odoo/meta.yaml
@@ -15,7 +15,14 @@ description:
   of developers and business experts. Whether you need a CRM, eCommerce,
   accounting, inventory, project management, or any other business application,
   Odoo has got you covered.
-instructions:
+instructions: >-
+  Odoo does not ship with a database pre-created, so the home page will 500 with
+  a "Database ... not initialized" error until you set one up. Visit
+  /web/database/manager on your assigned domain — that page works even while the
+  home page is erroring, since it doesn't need an initialized database. If it
+  lists an existing empty database (e.g. matching your project name), delete it,
+  then use Create Database to set a master password and your first real
+  database. Once that finishes, the home page will load normally.
 changeLog:
   - date: 2023
     description: first release
@@ -24,7 +31,8 @@ changeLog:
   - date: 2026-07-27
     description:
       Fixed crash on startup — Odoo refuses to boot when the database user is
-      named "postgres", so the database user is now "odoo"
+      named "postgres", so the database user is now "odoo" — and added
+      instructions for setting up the first database via /web/database/manager
 links:
   - label: Website
     url: https://www.odoo.com

--- a/templates/odoo/meta.yaml
+++ b/templates/odoo/meta.yaml
@@ -21,6 +21,10 @@ changeLog:
     description: first release
   - date: 2025-12-29
     description: Version bumped to 19.0
+  - date: 2026-07-27
+    description:
+      Fixed crash on startup — Odoo refuses to boot when the database user is
+      named "postgres", so the database user is now "odoo"
 links:
   - label: Website
     url: https://www.odoo.com


### PR DESCRIPTION
Odoo's official Docker entrypoint refuses to boot when the Postgres connection user is literally named "postgres", as a hardcoded security guard. The template's Postgres service and app env both used that username, so every deploy crash-looped. Switched the database user to "odoo".