### PR TITLE
Update Redis Insight template to the latest image tag

### DIFF
--- a/templates/redisinsight/meta.yaml
+++ b/templates/redisinsight/meta.yaml
@@ -33,7 +33,7 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: redis/redisinsight:2.70.1
+      default: redis/redisinsight:latest
 
 benefits:
   - title: Visual Data Exploration


### PR DESCRIPTION
## What
Updates the **Redis Insight** template default image from `redis/redisinsight:2.70.1` to `redis/redisinsight:latest`.

## Why
`2.70.1` was published in **July 2025**; the current release is **3.8.0**. As-is, every one-click deployment of this template starts ~13 months behind and misses bug fixes, security updates, and newer features. Defaulting to `:latest` keeps new deployments on the current Redis Insight build.

## Change
Single line in `templates/redisinsight/meta.yaml`:
```diff
-      default: redis/redisinsight:2.70.1
+      default: redis/redisinsight:latest
```

Happy to pin to a specific current version (e.g. `3.8.0`) instead if you prefer explicit pins over the floating `latest` tag — just let me know.