### PR TITLE
fix: point Velix API template website link to GitHub repo

### DIFF
--- a/templates/velix-api/meta.yaml
+++ b/templates/velix-api/meta.yaml
@@ -15,7 +15,7 @@ changeLog:
     description: first release
 links:
   - label: Website
-    url: https://velix.dev
+    url: https://github.com/paulolinder/velix-api
   - label: Documentation
     url: https://github.com/paulolinder/velix-api
   - label: Github

--- a/templates/velix-api/meta.yaml
+++ b/templates/velix-api/meta.yaml
@@ -38,7 +38,7 @@ schema:
     appServiceImage:
       type: string
       title: App Service Image
-      default: ghcr.io/paulolinder/velix-api:0.1.0
+      default: ghcr.io/paulolinder/velix-api:latest
     databaseServiceName:
       type: string
       title: Database Service Name


### PR DESCRIPTION
## Summary
- Velix API is now fully open on GitHub. The template's `Website` link pointed to `velix.dev` (a separate marketing site); this updates it to point to the GitHub repo, consistent with the `Documentation`/`Github` links already in the template.
- Also updates the pinned image tag from `0.1.0` (stale, predates the project's actual v1.0.0 tag and is no longer rebuilt) to `latest`, which `release.yml` pushes on every push to master and is the tag that actually stays current.

## Test plan
- [x] Verified `templates/velix-api/meta.yaml` parses as valid YAML
- [x] Confirmed via GHCR API that `:latest` has a newer digest than `:0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)